### PR TITLE
post-message: advertise User-Agent + pin Roam API version (v4.0.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@actions/core": "^3.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions",
-  "version": "2.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions",
-      "version": "2.0.1",
+      "version": "4.0.2",
       "dependencies": {
         "@actions/core": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions",
-  "version": "2.0.1",
+  "version": "4.0.2",
   "private": true,
   "description": "Roam GitHub Actions",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Roam GitHub Actions",
   "dependencies": {

--- a/post-message/index.mjs
+++ b/post-message/index.mjs
@@ -1,4 +1,25 @@
 import * as core from "@actions/core";
+import { createRequire } from "node:module";
+
+// Version is read from package.json (single source of truth) so a release only
+// bumps it in one place. Guarded so a missing/garbled manifest can never break
+// posting — the User-Agent is best-effort attribution, not a hard dependency.
+let pluginVersion = "0+unknown";
+try {
+  pluginVersion =
+    createRequire(import.meta.url)("../package.json").version || pluginVersion;
+} catch {
+  // keep the fallback
+}
+
+// Advertised on every request so the appserver can attribute traffic to this
+// action and version (Datadog @plugin.name:roam-actions / @plugin.version).
+const USER_AGENT = `roam-actions/${pluginVersion}`;
+
+// The Roam API version this action is built and tested against, pinned via the
+// Roam-Version header so future /v1/ shape changes don't reach it until the
+// version is bumped in lockstep with the code.
+const ROAM_API_VERSION = "2026-06-01";
 
 const TAGGED_ID_PATTERN =
   /^([A-Za-z])-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
@@ -90,6 +111,8 @@ function buildRequest({ apiKey, chatId, text, blocks, color }) {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+        "Roam-Version": ROAM_API_VERSION,
       },
       body,
     },


### PR DESCRIPTION
## What
The `post-message` action now sends `User-Agent: roam-actions/<version>` and `Roam-Version: 2026-06-01` on its `chat.post` request.

## Why
Brings the public Roam GitHub Action in line with the other integrations (openclaw-roam, n8n-nodes-roam, roam-zapier, hermes-roam):
- **User-Agent** → the appserver attributes traffic by source + version (Datadog `@plugin.name:roam-actions` / `@plugin.version`). Previously these requests carried the runtime's generic default.
- **Roam-Version** → the server is adding Stripe-style dated API versioning; pinning `2026-06-01` keeps this action's `/v1/chat.post` contract stable until `ROAM_API_VERSION` is bumped in lockstep with the code (instead of being at the mercy of when the caller's API key was created).

## How
- Both headers added in `buildRequest()` (the single place request options are built). The action posts only `chat.post` (no webhooks), so no subscribe `version` param.
- **Version sourcing:** read from `package.json` at runtime via `createRequire`, guarded with a fallback so a missing/garbled manifest can never break posting. The whole action repo (incl. package.json) is checked out when the action runs, so `../package.json` resolves.
- **Version bump:** `2.0.0` → `4.0.2`. package.json had drifted two majors behind the real release line (git tags are at `v4.0.1`); now that the version is advertised over the wire it must match the release, so package.json is realigned to the tags and bumped to the next patch (per @derekcicerone). **Note: releases must now bump package.json in lockstep with the tag** — it's no longer cosmetic.

## Safety / timing
No-op until the server's API versioning ships; an unknown `Roam-Version` header is ignored. Pinned to Baseline `2026-06-01` (always Supported). Should be live before the first real version (`2026-09-01`) goes Latest.

## Test
`node --check` passes; verified the version resolves to `roam-actions/4.0.2` via the same `createRequire("../package.json")` path the action uses at runtime (Node 24). No test suite / CI in this repo.
